### PR TITLE
fix: ignore export assign cannot be used in module TS error, fixes #1018

### DIFF
--- a/dist/purify.cjs.d.ts
+++ b/dist/purify.cjs.d.ts
@@ -398,4 +398,5 @@ type WindowLike = Pick<typeof globalThis, 'DocumentFragment' | 'HTMLTemplateElem
 
 export { type Config, type Hook, type HookName, type RemovedAttribute, type RemovedElement, type UponSanitizeAttributeHook, type UponSanitizeAttributeHookEvent, type UponSanitizeElementHook, type UponSanitizeElementHookEvent, type WindowLike };
 
+// @ts-ignore
 export = _default;

--- a/scripts/fix-cjs-types.js
+++ b/scripts/fix-cjs-types.js
@@ -22,7 +22,7 @@ const path = require('node:path');
   // Append `export = _default;` to match the
   // `module.exports = DOMPurify` statement
   // that Rollup creates.
-  fixed += '\nexport = _default;\n';
+  fixed += '\n// @ts-ignore\nexport = _default;\n';
 
   await fs.writeFile(fileName, fixed);
 })().catch((ex) => {


### PR DESCRIPTION
## Summary

Fixes issue #1018 by simply ignoring the TypeScript error since the TS error has no negative effect whatsoever on the functionality of these types. This makes TypeScript and "Are the Types Wrong" both happy and everything is back to normal

![image](https://github.com/user-attachments/assets/4816846b-4e0e-4a0f-8910-367873973c3b)


## Background & Context

![image](https://github.com/user-attachments/assets/6a18480f-b75d-4424-ae91-e953c7f1fe81)

## Tasks

Simply modified the existing `fix-cjs-types.js` script

## Dependencies

<!-- If there are any dependencies on PRs or API work then list them here. -->

- [x] Resolved dependency
- [ ] Open dependency
